### PR TITLE
Fix clients and remove caching

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,10 @@ setup(
     author_email='pogzyb@umich.edu',
     python_requires='>=3.6, <4',
     keywords='security, whois, rdap, research',
-    install_requires=['httpx>=0.18.1'],
+    install_requires=[
+        'httpx>=0.18.1',
+        'async_generator>=1.10; python_version < "3.7.0"'
+    ],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,6 +10,7 @@ class TestDNSClient(asynctest.TestCase):
     def setUp(self) -> None:
         self.dns_client = DNSClient.new_client()
 
+
     def test_build_query_url(self):
         expected_base_case = "http://some-url.com/domain/domain-name"
         output = self.dns_client._build_query_uri("http://some-url.com/", "domain-name")
@@ -95,3 +96,19 @@ class TestDNSClient(asynctest.TestCase):
         self.dns_client.httpx_client = mock_client
         resp = await self.dns_client._aio_get_request("https://www.some-domain.com")
         assert resp == fake_http_response, f"{resp} != {fake_http_response}"
+
+    async def test_async_context_manager(self):
+        fake_http_response = "fake-http-response"
+        mock_client = mock.Mock(get=mock.CoroutineMock(return_value=fake_http_response))
+        async with DNSClient.new_aio_client_context() as aio_dns_client:
+            aio_dns_client.httpx_client = mock_client
+            resp = await aio_dns_client._aio_get_request("https://www.some-domain.com")
+            assert resp == fake_http_response, f"{resp} != {fake_http_response}"
+
+    def text_context_manager(self):
+        fake_http_response = "fake-http-response"
+        mock_client = mock.Mock(get=mock.Mock(return_value=fake_http_response))
+        with DNSClient.new_client_context() as dns_client:
+            dns_client.httpx_client = mock_client
+            resp = dns_client._get_request("https://www.some-domain.com")
+            assert resp == fake_http_response, f"{resp} != {fake_http_response}"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ from whodap.errors import RateLimitError, NotFoundError, MalformedQueryError
 class TestDNSClient(asynctest.TestCase):
 
     def setUp(self) -> None:
-        self.dns_client = DNSClient()
+        self.dns_client = DNSClient.new_client()
 
     def test_build_query_url(self):
         expected_base_case = "http://some-url.com/domain/domain-name"
@@ -65,7 +65,7 @@ class TestDNSClient(asynctest.TestCase):
                 ]
             ]
         }
-        self.dns_client._set_iana_dns_info(rdap_output)
+        self.dns_client.set_iana_dns_info(rdap_output)
         assert len(self.dns_client.iana_dns_server_map.keys()) == 4
         assert self.dns_client.publication == "2021-05-05"
         assert self.dns_client.version == "2"
@@ -73,28 +73,25 @@ class TestDNSClient(asynctest.TestCase):
     @mock.patch("whodap.client.DNSClient._aio_get_request")
     async def test_aio_load_dns(self, mock_request):
         mock_request.return_value = mock.Mock(status_code=200, json=mock.Mock())
-        await self.dns_client._aio_load_from_iana()
+        await self.dns_client.aio_get_iana_dns_info()
         mock_request.assert_called_once()
 
     @mock.patch("whodap.client.DNSClient._get_request")
     def test_load_dns(self, mock_request):
         mock_request.return_value = mock.Mock(status_code=200, json=mock.Mock())
-        self.dns_client._load_from_iana()
+        self.dns_client.get_iana_dns_info()
         mock_request.assert_called_once()
 
     def test_get_request(self):
         fake_http_response = "fake-http-response"
-        mock_client = mock.MagicMock()
-        mock_client.__enter__.return_value = mock.Mock(get=mock.Mock(return_value=fake_http_response))
-        self.dns_client.session = mock_client
+        mock_client = mock.Mock(get=mock.Mock(return_value=fake_http_response))
+        self.dns_client.httpx_client = mock_client
         resp = self.dns_client._get_request("https://www.some-domain.com")
         assert resp == fake_http_response, f"{resp} != {fake_http_response}"
 
     async def test_get_aio_request(self):
         fake_http_response = "fake-http-response"
-        mock_client = mock.MagicMock()
-        mock_client.__aenter__.return_value = mock.CoroutineMock(
-            get=mock.CoroutineMock(return_value=fake_http_response))
-        self.dns_client.session = mock_client
+        mock_client = mock.Mock(get=mock.CoroutineMock(return_value=fake_http_response))
+        self.dns_client.httpx_client = mock_client
         resp = await self.dns_client._aio_get_request("https://www.some-domain.com")
         assert resp == fake_http_response, f"{resp} != {fake_http_response}"

--- a/tests/test_package_methods.py
+++ b/tests/test_package_methods.py
@@ -1,7 +1,7 @@
 import asynctest
 import asynctest.mock as mock
 
-from whodap import lookup_domain, aio_lookup_domain, DNSClient
+from whodap import lookup_domain, aio_lookup_domain
 
 
 class TestPackageMethods(asynctest.TestCase):
@@ -9,27 +9,22 @@ class TestPackageMethods(asynctest.TestCase):
     Tests that the appropriate classes and methods are invoked for each package method.
     """
 
-    @mock.patch('whodap.get_cached_dns_client')
     @mock.patch('whodap.DNSClient')
-    def test_lookup_domain(self, mock_dns_client, mock_cache_call):
+    def test_lookup_domain(self, mock_dns_client):
         confirmation_string = 'dns_client_lookup_was_called'
         mock_dns_client.lookup.return_value = confirmation_string
         mock_dns_client.new_client.return_value = mock_dns_client
-        mock_cache_call.return_value = mock_dns_client
         resp = lookup_domain(domain='some-domain', tld='com')
         assert resp == confirmation_string, f"{resp} != {confirmation_string}"
-        resp = lookup_domain(domain='some-domain', tld='com', cache=False)
+        resp = lookup_domain(domain='some-domain', tld='com')
         assert resp == confirmation_string, f"{resp} != {confirmation_string}"
-        mock_cache_call.assert_called_once()
 
-    @mock.patch('whodap.get_cached_aio_dns_client')
     @mock.patch('whodap.DNSClient')
-    async def test_aio_lookup_domain(self, mock_dns_client, mock_cache_call):
+    async def test_aio_lookup_domain(self, mock_dns_client):
         confirmation_string = 'dns_client_aio_lookup_was_called'
         mock_dns_client.aio_lookup = mock.CoroutineMock(return_value=confirmation_string)
         mock_dns_client.new_aio_client = mock.CoroutineMock(return_value=mock_dns_client)
-        mock_cache_call.return_value = mock_dns_client
         resp = await aio_lookup_domain(domain='some-domain', tld='com')
         assert resp == confirmation_string, f"{resp} != {confirmation_string}"
-        resp = await aio_lookup_domain(domain='some-domain', tld='com', cache=False)
+        resp = await aio_lookup_domain(domain='some-domain', tld='com')
         assert resp == confirmation_string, f"{resp} != {confirmation_string}"

--- a/whodap/client.py
+++ b/whodap/client.py
@@ -1,8 +1,15 @@
+import sys
 import posixpath
 import ipaddress
 from abc import ABC, abstractmethod
 from typing import Dict, Any, Union, Optional
-from contextlib import contextmanager, asynccontextmanager
+from contextlib import contextmanager
+
+# different installs for async contextmanager based on python version
+if sys.version_info.major == 3 and sys.version_info.minor < 7:
+    from async_generator import asynccontextmanager
+else:
+    from contextlib import asynccontextmanager
 
 import httpx
 
@@ -12,7 +19,6 @@ from .response import DomainResponse
 
 
 class RDAPClient(ABC):
-
     _iana_publication_key: str = 'publication'
     _iana_verison_key: str = 'version'
     _iana_services_key: str = 'services'
@@ -25,7 +31,6 @@ class RDAPClient(ABC):
 
     @classmethod
     @abstractmethod
-    @contextmanager
     def new_client_context(cls, httpx_client):
         ...
 
@@ -36,7 +41,6 @@ class RDAPClient(ABC):
 
     @classmethod
     @abstractmethod
-    @asynccontextmanager
     async def new_aio_client_context(cls, httpx_client):
         ...
 
@@ -82,7 +86,6 @@ class RDAPClient(ABC):
 
 
 class DNSClient(RDAPClient):
-
     # IANA DNS
     _iana_uri: str = 'https://data.iana.org/rdap/dns.json'
 
@@ -271,7 +274,6 @@ class DNSClient(RDAPClient):
 
 
 class IPv4Client(RDAPClient):
-
     # IANA IPv4
     _iana_uri: str = 'https://data.iana.org/rdap/ipv4.json'
     _arin_registry_uri: str = 'https://rdap.arin.net/registry/ip/'
@@ -303,7 +305,6 @@ class IPv4Client(RDAPClient):
 
 
 class IPv6Client(RDAPClient):
-
     # IANA IPv6
     ...
 
@@ -327,7 +328,6 @@ class IPv6Client(RDAPClient):
 
 
 class ASNClient(RDAPClient):
-
     # IANA ASN
     ...
 

--- a/whodap/utils.py
+++ b/whodap/utils.py
@@ -1,19 +1,4 @@
 from enum import Enum
-from functools import lru_cache
-
-
-@lru_cache(maxsize=1)
-def get_cached_dns_client(**kwargs):
-    from .client import DNSClient
-    c = DNSClient.new_client(**kwargs)
-    return c
-
-
-@lru_cache(maxsize=1)
-async def get_cached_aio_dns_client(**kwargs):
-    from .client import DNSClient
-    c = await DNSClient.new_aio_client(**kwargs)
-    return c
 
 
 class RDAPVCardKeys(str, Enum):


### PR DESCRIPTION
Caching seems like a premature optimization at this time. The only thing that really needs to be cached is the initial server list from IANA, but once that's read in at start up, performance is fine. Examples will be added to the README to demonstrate how to use the client. The broken async client was fixed. There are still no tests for the async client.