### PR TITLE
Set follow_redirects=True

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     python_requires='>=3.6, <4',
     keywords='security, whois, rdap, research',
     install_requires=[
-        'httpx>=0.18.1',
+        'httpx>=0.20.0',
         'async_generator>=1.10; python_version < "3.7.0"'
     ],
     classifiers=[

--- a/whodap/__init__.py
+++ b/whodap/__init__.py
@@ -126,7 +126,7 @@ async def aio_lookup_ipv4(
 def lookup_ipv6(
     ipv6: Union[str, ipaddress.IPv6Address],
     httpx_client: Optional[Client] = None
-) -> IPv4Response:
+) -> IPv6Response:
     """
     Convenience function that instantiates an IPv6Client,
     submits an RDAP query for the given IP address, and
@@ -150,7 +150,7 @@ def lookup_ipv6(
 async def aio_lookup_ipv6(
     ipv6: Union[str, ipaddress.IPv6Address],
     httpx_client: Optional[AsyncClient] = None
-) -> IPv4Response:
+) -> IPv6Response:
     """
     Convenience function that instantiates an IPv6Client,
     submits an RDAP query for the given IP address, and

--- a/whodap/client.py
+++ b/whodap/client.py
@@ -83,7 +83,7 @@ class RDAPClient:
         :httpx_client: pre-configured instance of `httpx.Client`
         :return: yields the initialized DNSClient
         """
-        client = cls(httpx_client or httpx.Client(timeout=10))
+        client = cls(httpx_client or httpx.Client(follow_redirects=True, timeout=10))
         try:
             iana_dns_info = client._get_iana_info()
             client._set_iana_info(iana_dns_info)
@@ -101,7 +101,7 @@ class RDAPClient:
         :return: DNSClient with a sync httpx_client
         """
         # init the client with a default httpx.Client if one is not provided
-        client = cls(httpx_client or httpx.Client(timeout=10))
+        client = cls(httpx_client or httpx.Client(follow_redirects=True, timeout=10))
         # load the dns server information from IANA
         iana_info = client._get_iana_info()
         # parse and save the server information
@@ -118,7 +118,7 @@ class RDAPClient:
         :httpx_client: Optional pre-configured instance of `httpx.AsyncClient`
         :return: yields the initialized DNSClient
         """
-        client = cls(httpx_client or httpx.AsyncClient(timeout=10))
+        client = cls(httpx_client or httpx.AsyncClient(follow_redirects=True, timeout=10))
         try:
             iana_info = await client._aio_get_iana_info()
             client._set_iana_info(iana_info)
@@ -135,7 +135,7 @@ class RDAPClient:
         :httpx_client: pre-configured instance of `httpx.AsyncClient`
         :return: DNSClient with an async httpx_client
         """
-        client = cls(httpx_client or httpx.AsyncClient(timeout=10))
+        client = cls(httpx_client or httpx.AsyncClient(follow_redirects=True, timeout=10))
         iana_info = await client._aio_get_iana_info()
         client._set_iana_info(iana_info)
         return client
@@ -237,9 +237,9 @@ class RDAPClient:
         return resp
 
     def _check_next_href(
-            self,
-            current_href: str,
-            links: List[Dict[str, str]]
+        self,
+        current_href: str,
+        links: List[Dict[str, str]]
     ) -> Optional[str]:
         # RFC: https://datatracker.ietf.org/doc/html/rfc9083#section-4.2
         # find next href or return None


### PR DESCRIPTION
Version 0.20.0 of httpx added the paramater `follow_redirects=False` to its Client and Request classes. This causes issues for some RDAP requests where the RIR redirects (303 "See Other") the client to the actual authority.

#10 