### PR TITLE
Add missing "or resp" to client

### DIFF
--- a/whodap/client.py
+++ b/whodap/client.py
@@ -198,7 +198,7 @@ class RDAPClient:
         if links:
             next_href = self._check_next_href(href, links)
             if next_href:
-                resp = self._get_authoritative_response(next_href, depth+1)
+                resp = self._get_authoritative_response(next_href, depth+1) or resp
         # return authoritative response
         return resp
 


### PR DESCRIPTION
Fixes what appears to be a small bug. The "or resp" was left off the recursive call in `_get_authoritative_response`, which caused "Nonetype" errors in other parts of execution.