### PR TITLE
Add basic response validation to `to_whois_dict`

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,37 @@ async with whodap.DNSClient.new_aio_client_context(aio_httpx_client) as dns_clie
         response = await dns_client.aio_lookup(domain, tld)
 ```
 
+- Using the `to_whois_dict` method
+```python
+import logging
+
+from whodap import lookup_domain
+from whodap.errors import RDAPConformanceException
+
+logger = logging.getLogger(__name__)
+
+# strict = False (default)
+rdap_response = lookup_domain("example", "com")
+whois_format = rdap_response.to_whois_dict()
+logger.info(f"whois={whois_format}")
+# Given a valid RDAP response, the `to_whois_dict` method will attempt to
+# convert the RDAP format into a flattened dictionary of Whois key/values
+
+# strict = True
+try:
+    # Unfortunately, there are instances in which the RDAP protocol is not
+    # properly implemented by the registrar. By default, the `to_whois_dict`
+    # will still attempt to parse the into the whois dictionary. However,
+    # there is no guarantee that the information will be correct/non-null. 
+    # If your applications rely on accurate information, the `strict=True`
+    # parameter will raise an `RDAPConformanceException` when encountering
+    # invalid or incorrectly formatted RDAP responses.
+    rdap_response = lookup_domain("example", "com")
+    whois_format = rdap_response.to_whois_dict(strict=True)
+except RDAPConformanceException:
+    logger.exception("RDAP response is incorrectly formatted.")
+```
+
 #### Contributions
 - Interested in contributing? 
 - Have any questions or comments? 
@@ -184,6 +215,7 @@ Please post a question or comment.
 - ~~Support for RDAP "domain" queries~~
 - ~~Support for RDAP "ipv4" and "ipv6" queries~~
 - ~~Support for RDAP ASN queries~~
+- Add full-validation support
 - Abstract the HTTP Client (`httpx` is the defacto client for now)
 - Add parser utils/helpers for IPv4, IPv6, and ASN Responses (if someone shows interest)
 

--- a/README.md
+++ b/README.md
@@ -184,14 +184,14 @@ rdap_response = lookup_domain("example", "com")
 whois_format = rdap_response.to_whois_dict()
 logger.info(f"whois={whois_format}")
 # Given a valid RDAP response, the `to_whois_dict` method will attempt to
-# convert the RDAP format into a flattened dictionary of Whois key/values
+# convert the RDAP format into a flattened dictionary of WHOIS key/values
 
 # strict = True
 try:
     # Unfortunately, there are instances in which the RDAP protocol is not
     # properly implemented by the registrar. By default, the `to_whois_dict`
-    # will still attempt to parse the into the whois dictionary. However,
-    # there is no guarantee that the information will be correct/non-null. 
+    # will still attempt to parse the into the WHOIS dictionary. However,
+    # there is no guarantee that the information will be correct or non-null. 
     # If your applications rely on accurate information, the `strict=True`
     # parameter will raise an `RDAPConformanceException` when encountering
     # invalid or incorrectly formatted RDAP responses.
@@ -215,11 +215,10 @@ Please post a question or comment.
 - ~~Support for RDAP "domain" queries~~
 - ~~Support for RDAP "ipv4" and "ipv6" queries~~
 - ~~Support for RDAP ASN queries~~
-- Add full-validation support
 - Abstract the HTTP Client (`httpx` is the defacto client for now)
 - Add parser utils/helpers for IPv4, IPv6, and ASN Responses (if someone shows interest)
+- Add RDAP response validation support leveraging [ICANN's tool](https://github.com/icann/rdap-conformance-tool/)
 
 #### RDAP Resources:
-- https://rdap.org/
-- https://tools.ietf.org/html/rfc7483 
-- https://tools.ietf.org/html/rfc6350
+- [rdap.org](https://rdap.org/)
+- [RFC 9082](https://datatracker.ietf.org/doc/html/rfc9082) 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ async with whodap.DNSClient.new_aio_client_context(aio_httpx_client) as dns_clie
         response = await dns_client.aio_lookup(domain, tld)
 ```
 
-- Using the `to_whois_dict` method
+- Using the `to_whois_dict` method and `RDAPConformanceException`
 ```python
 import logging
 

--- a/tests/samples/bad_response_01.json
+++ b/tests/samples/bad_response_01.json
@@ -1,0 +1,420 @@
+{
+  "handle": null,
+  "ldhName": "something-not-real.com",
+  "nameServers": [
+    {
+      "ldhName": "a.share-dns.com",
+      "status": [
+        "active"
+      ],
+      "objectClassName": "nameserver",
+      "lang": "en"
+    },
+    {
+      "ldhName": "b.share-dns.net",
+      "status": [
+        "active"
+      ],
+      "objectClassName": "nameserver",
+      "lang": "en"
+    }
+  ],
+  "secureDNS": {
+    "delegationSigned": false
+  },
+  "entities": [
+    {
+      "vcardArray": [
+        "vcard",
+        [
+          "version",
+          "{}",
+          "text",
+          "4.0"
+        ],
+        [
+          "kind",
+          "{}",
+          "text",
+          "individual"
+        ],
+        [
+          "fn",
+          "{}",
+          "text",
+          "Domain"
+        ],
+        [
+          "adr",
+          "{}",
+          "text"
+        ],
+        [
+          [
+            "{}",
+            "{}",
+            "City, State, undefined"
+          ],
+          "New York",
+          "Nebraska",
+          "10001",
+          "United States"
+        ],
+        [
+          "email",
+          "{}",
+          "text",
+          "cwp7panel@gmail.com"
+        ],
+        [
+          "tel",
+          {
+            "type": "voice"
+          },
+          "uri",
+          "+1.123456789"
+        ]
+      ],
+      "status": [
+        "Active"
+      ],
+      "roles": [
+        "registrant"
+      ],
+      "objectClassName": "entity",
+      "lang": "en"
+    },
+    {
+      "vcardArray": [
+        "vcard",
+        [
+          "version",
+          "{}",
+          "text",
+          "4.0"
+        ],
+        [
+          "kind",
+          "{}",
+          "text",
+          "individual"
+        ],
+        [
+          "fn",
+          "{}",
+          "text",
+          "Domain"
+        ],
+        [
+          "adr",
+          "{}",
+          "text"
+        ],
+        [
+          [
+            "{}",
+            "{}",
+            "City, State, undefined"
+          ],
+          "New York",
+          "Nebraska",
+          "10001",
+          "United States"
+        ],
+        [
+          "email",
+          "{}",
+          "text",
+          "cwp7panel@gmail.com"
+        ],
+        [
+          "tel",
+          {
+            "type": "voice"
+          },
+          "uri",
+          "+1.123456789"
+        ]
+      ],
+      "status": [
+        "Active"
+      ],
+      "objectClassName": "entity",
+      "lang": "en"
+    },
+    {
+      "vcardArray": [
+        "vcard",
+        [
+          "version",
+          "{}",
+          "text",
+          "4.0"
+        ],
+        [
+          "kind",
+          "{}",
+          "text",
+          "individual"
+        ],
+        [
+          "fn",
+          "{}",
+          "text",
+          "Domain"
+        ],
+        [
+          "adr",
+          "{}",
+          "text"
+        ],
+        [
+          [
+            "{}",
+            "{}",
+            "City, State, undefined"
+          ],
+          "New York",
+          "Nebraska",
+          "10001",
+          "United States"
+        ],
+        [
+          "email",
+          "{}",
+          "text",
+          "cwp7panel@gmail.com"
+        ],
+        [
+          "tel",
+          {
+            "type": "voice"
+          },
+          "uri",
+          "+1.123456789"
+        ]
+      ],
+      "status": [
+        "Active"
+      ],
+      "roles": [
+        "billing"
+      ],
+      "objectClassName": "entity",
+      "lang": "en"
+    },
+    {
+      "vcardArray": [
+        "vcard",
+        [
+          "version",
+          "{}",
+          "text",
+          "4.0"
+        ],
+        [
+          "kind",
+          "{}",
+          "text",
+          "individual"
+        ],
+        [
+          "fn",
+          "{}",
+          "text",
+          "Domain"
+        ],
+        [
+          "adr",
+          "{}",
+          "text"
+        ],
+        [
+          [
+            "{}",
+            "{}",
+            "City, State, undefined"
+          ],
+          "New York",
+          "Nebraska",
+          "10001",
+          "United States"
+        ],
+        [
+          "email",
+          "{}",
+          "text",
+          "cwp7panel@gmail.com"
+        ],
+        [
+          "tel",
+          {
+            "type": "voice"
+          },
+          "uri",
+          "+1.123456789"
+        ]
+      ],
+      "status": [
+        "Active"
+      ],
+      "roles": [
+        "tech"
+      ],
+      "objectClassName": "entity",
+      "lang": "en"
+    },
+    {
+      "vcardArray": [
+        [
+          "version",
+          "{}",
+          "text",
+          "4.0"
+        ],
+        [
+          "version",
+          "{}",
+          "text",
+          "4.0"
+        ]
+      ],
+      "status": [
+        "active"
+      ],
+      "roles": [
+        "Registrar"
+      ],
+      "objectClassName": "entity",
+      "lang": "en",
+      "publicIds": [
+        {
+          "type": "IANA Registrar ID",
+          "identifier": "1250"
+        }
+      ],
+      "entities": {
+        "vcardArray": [
+          "vcard",
+          [
+            [
+              "version",
+              "{}",
+              "text",
+              "4.0"
+            ],
+            [
+              "org",
+              "{}",
+              "text",
+              "OwnRegistrar Inc"
+            ],
+            [
+              "fn",
+              "{}",
+              "text",
+              "individual"
+            ],
+            [
+              "tel",
+              {
+                "type": "voice"
+              },
+              "uri",
+              "+1.212 401 6235"
+            ],
+            [
+              "email",
+              "{}",
+              "text",
+              "abuse@ownregistrar.com"
+            ]
+          ]
+        ],
+        "status": [
+          "active"
+        ],
+        "roles": [
+          "Registrar"
+        ],
+        "objectClassName": "abuse",
+        "lang": "en"
+      },
+      "links": [
+        {
+          "title": "Registrar URL",
+          "type": "application/rdap+json",
+          "rel": "self",
+          "href": "www.ownregistrar.com"
+        }
+      ]
+    }
+  ],
+  "status": [
+    "active"
+  ],
+  "events": [
+    {
+      "eventAction": "registration",
+      "eventDate": "2023-07-05T00:00:00"
+    },
+    {
+      "eventAction": "expiration",
+      "eventDate": "2024-07-05T00:00:00"
+    },
+    {
+      "eventAction": "last changed",
+      "eventDate": "2023-07-05T00:00:00"
+    },
+    {
+      "eventAction": "last update of RDAP database",
+      "eventDate": "2023-10-02T15:31:50"
+    }
+  ],
+  "notices": [
+    {
+      "title": "Status Codes",
+      "description": [
+        "For more information on domain status codes, please visit https://icann.org/epp"
+      ],
+      "links": [
+        {
+          "title": "More information on domain status codes",
+          "type": "text/html",
+          "rel": "related",
+          "href": "https://icann.org/epp"
+        }
+      ]
+    },
+    {
+      "title": "RDDS Inaccuracy Complaint Form",
+      "description": [
+        "URL of the ICANN RDDS Inaccuracy Complaint Form: https://www.icann.org/wicf/."
+      ],
+      "links": [
+        {
+          "title": "CANN RDDS Inaccuracy Complaint Form",
+          "type": "text/html",
+          "rel": "related",
+          "href": "https://www.icann.org/wicf/"
+        }
+      ]
+    },
+    {
+      "title": "Terms of Use",
+      "links": [
+        {
+          "title": "Terms of Use",
+          "href": "https://rdapserver.net/terms-of-use/"
+        }
+      ]
+    }
+  ],
+  "rdapConformance": [
+    "icann_rdap_response_profile_0",
+    "icann_rdap_technical_implementation_guide_0",
+    "rdap_level_0"
+  ],
+  "objectClassName": "domain",
+  "lang": "en"
+}

--- a/tests/samples/bad_response_02.json
+++ b/tests/samples/bad_response_02.json
@@ -1,0 +1,80 @@
+{
+  "handle": null,
+  "ldhName": "something-not-real.com",
+  "nameServers": [
+    "BOOOOOM"
+  ],
+  "secureDNS": {
+    "delegationSigned": false
+  },
+  "entities": [
+    {"vcardArray": {}}
+  ],
+  "status": [
+    "active"
+  ],
+  "events": [
+    {
+      "eventAction": "registration",
+      "eventDate": "2023-07-05T00:00:00"
+    },
+    {
+      "eventAction": "expiration",
+      "eventDate": "2024-07-05T00:00:00"
+    },
+    {
+      "eventAction": "last changed",
+      "eventDate": "2023-07-05T00:00:00"
+    },
+    {
+      "eventAction": "last update of RDAP database",
+      "eventDate": "2023-10-02T15:31:50"
+    }
+  ],
+  "notices": [
+    {
+      "title": "Status Codes",
+      "description": [
+        "For more information on domain status codes, please visit https://icann.org/epp"
+      ],
+      "links": [
+        {
+          "title": "More information on domain status codes",
+          "type": "text/html",
+          "rel": "related",
+          "href": "https://icann.org/epp"
+        }
+      ]
+    },
+    {
+      "title": "RDDS Inaccuracy Complaint Form",
+      "description": [
+        "URL of the ICANN RDDS Inaccuracy Complaint Form: https://www.icann.org/wicf/."
+      ],
+      "links": [
+        {
+          "title": "CANN RDDS Inaccuracy Complaint Form",
+          "type": "text/html",
+          "rel": "related",
+          "href": "https://www.icann.org/wicf/"
+        }
+      ]
+    },
+    {
+      "title": "Terms of Use",
+      "links": [
+        {
+          "title": "Terms of Use",
+          "href": "https://rdapserver.net/terms-of-use/"
+        }
+      ]
+    }
+  ],
+  "rdapConformance": [
+    "icann_rdap_response_profile_0",
+    "icann_rdap_technical_implementation_guide_0",
+    "rdap_level_0"
+  ],
+  "objectClassName": "domain",
+  "lang": "en"
+}

--- a/whodap/errors.py
+++ b/whodap/errors.py
@@ -17,5 +17,6 @@ class MalformedQueryError(WhodapError):
 class BadStatusCode(WhodapError):
     ...
 
+
 class RDAPConformanceException(WhodapError):
     ...

--- a/whodap/errors.py
+++ b/whodap/errors.py
@@ -16,3 +16,6 @@ class MalformedQueryError(WhodapError):
 
 class BadStatusCode(WhodapError):
     ...
+
+class RDAPConformanceException(WhodapError):
+    ...

--- a/whodap/response.py
+++ b/whodap/response.py
@@ -165,11 +165,17 @@ class DomainResponse(RDAPResponse):
             kwargs["default"] = self._encoder
         return dumps(self.to_whois_dict(), **kwargs)
 
-    def to_whois_dict(self, strict: bool = False) -> Dict[WHOISKeys, Union[str, List[str], datetime, None]]:
+    def to_whois_dict(
+        self, strict: bool = False
+    ) -> Dict[WHOISKeys, Union[str, List[str], datetime, None]]:
         """
         Returns the DomainResponse as "flattened" WHOIS dictionary;
         does not modify the original DomainResponse object.
 
+        :param strict: If True, raises an RDAPConformanceException if
+          the given RDAP response is incorrectly formatted. Otherwise
+          if False, the method will attempt to parse the RDAP response
+          without raising any exception.
         :return: dict with WHOIS keys
         """
         flat = {}
@@ -221,7 +227,9 @@ class DomainResponse(RDAPResponse):
         #  by a formal "validation" feature for the library or an implementation
         #  of the icann-tool: https://github.com/icann/rdap-conformance-tool
         if not isinstance(obj, list):
-            return RDAPConformanceException(f"entities type={type(obj)} is not an Array")
+            return RDAPConformanceException(
+                f"entities type={type(obj)} is not an Array"
+            )
 
     @staticmethod
     def _check_valid_vcardArray(obj: Any) -> Optional[RDAPConformanceException]:
@@ -229,7 +237,9 @@ class DomainResponse(RDAPResponse):
         #  by a formal "validation" feature for the library or an implementation
         #  of the icann-tool: https://github.com/icann/rdap-conformance-tool
         if not isinstance(obj, list):
-            return RDAPConformanceException(f"vcardArray type={type(obj)} is not an Array")
+            return RDAPConformanceException(
+                f"vcardArray type={type(obj)} is not an Array"
+            )
         elif len(obj) < 2:
             return RDAPConformanceException("vcardArray is incorrectly formatted")
         elif obj[0] != "vcard" and not isinstance(obj[-1], list):
@@ -319,7 +329,10 @@ class DomainResponse(RDAPResponse):
                                 #               or: ['tel', {"type": ["voice"]}, 'uri', 'tel:0000000']
                                 if hasattr(vcard[1], "type"):
                                     contact_type = vcard[1].to_dict().get("type")
-                                    if contact_type == "voice" or "voice" in contact_type:
+                                    if (
+                                        contact_type == "voice"
+                                        or "voice" in contact_type
+                                    ):
                                         ent_dict["phone"] = vcard_value
                                     elif contact_type == "fax" or "fax" in contact_type:
                                         ent_dict["fax"] = vcard_value

--- a/whodap/response.py
+++ b/whodap/response.py
@@ -232,7 +232,7 @@ class DomainResponse(RDAPResponse):
             )
 
     @staticmethod
-    def _check_valid_vcardArray(obj: Any) -> Optional[RDAPConformanceException]:
+    def _check_valid_vcardArray(obj: Any) -> Optional[RDAPConformanceException]:  # noqa
         # todo: this method will be removed in the future; replaced
         #  by a formal "validation" feature for the library or an implementation
         #  of the icann-tool: https://github.com/icann/rdap-conformance-tool

--- a/whodap/response.py
+++ b/whodap/response.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 from json import dumps, loads
 from types import SimpleNamespace
-from typing import Dict, Any, List, Union
+from typing import Dict, Any, List, Union, Optional
 
 from .utils import WHOISKeys, RDAPVCardKeys
+from .errors import RDAPConformanceException
 
 REDACTED = "REDACTED FOR PRIVACY"
 
@@ -164,7 +165,7 @@ class DomainResponse(RDAPResponse):
             kwargs["default"] = self._encoder
         return dumps(self.to_whois_dict(), **kwargs)
 
-    def to_whois_dict(self) -> Dict[WHOISKeys, Union[str, List[str], datetime, None]]:
+    def to_whois_dict(self, strict: bool = False) -> Dict[WHOISKeys, Union[str, List[str], datetime, None]]:
         """
         Returns the DomainResponse as "flattened" WHOIS dictionary;
         does not modify the original DomainResponse object.
@@ -187,7 +188,7 @@ class DomainResponse(RDAPResponse):
             flat.update(self._flat_dates(self.events))
 
         if getattr(self, "entities", None):
-            flat.update(self._flat_entities(self.entities))
+            flat.update(self._flat_entities(self.entities, strict))
 
         # convert dict keys over to "WHOISKeys"
         flat = self._construct_flat_dict(flat)
@@ -214,9 +215,48 @@ class DomainResponse(RDAPResponse):
         dates = dict([(event.eventAction, event.eventDate) for event in events])
         return dates
 
+    @staticmethod
+    def _check_valid_entities(obj: Any) -> Optional[RDAPConformanceException]:
+        # todo: this method will be removed in the future; replaced
+        #  by a formal "validation" feature for the library or an implementation
+        #  of the icann-tool: https://github.com/icann/rdap-conformance-tool
+        if not isinstance(obj, list):
+            return RDAPConformanceException(f"entities type={type(obj)} is not an Array")
+
+    @staticmethod
+    def _check_valid_vcardArray(obj: Any) -> Optional[RDAPConformanceException]:
+        # todo: this method will be removed in the future; replaced
+        #  by a formal "validation" feature for the library or an implementation
+        #  of the icann-tool: https://github.com/icann/rdap-conformance-tool
+        if not isinstance(obj, list):
+            return RDAPConformanceException(f"vcardArray type={type(obj)} is not an Array")
+        elif len(obj) < 2:
+            return RDAPConformanceException("vcardArray is incorrectly formatted")
+        elif obj[0] != "vcard" and not isinstance(obj[-1], list):
+            return RDAPConformanceException("vcardArray is incorrectly formatted")
+
+    @staticmethod
+    def _check_valid_vcard(obj: Any) -> Optional[RDAPConformanceException]:
+        # todo: this method will be removed in the future; replaced
+        #  by a formal "validation" feature for the library or an implementation
+        #  of the icann-tool: https://github.com/icann/rdap-conformance-tool
+        if not isinstance(obj, list):
+            return RDAPConformanceException(f"vCard type={type(obj)} is not an Array")
+        elif len(obj) < 4:
+            return RDAPConformanceException("vCard array length is less than < 4")
+
     def _flat_entities(
-        self, entities: List[SimpleNamespace]
+        self, entities: List[SimpleNamespace], strict: bool
     ) -> Dict[str, Dict[str, str]]:
+        # validate that entities is at least iterable
+        conformance_check_exc = self._check_valid_entities(entities)
+        if conformance_check_exc is not None:
+            if strict:
+                raise conformance_check_exc
+            else:
+                # skip because entity parsing is likely to fail
+                return {}
+        # attempt to parse entities
         entities_dict = {}
         for entity in entities:
             ent_dict = {}
@@ -229,53 +269,72 @@ class DomainResponse(RDAPResponse):
             # check for nested entities
             if hasattr(entity, "entities"):
                 # recursive call for nested entities
-                ent_dict = self._flat_entities(entity.entities)
+                ent_dict = self._flat_entities(entity.entities, strict)
                 entities_dict.update(ent_dict)
             # iterate through vCard array
             if hasattr(entity, "vcardArray"):
-                for vcard in entity.vcardArray[-1]:
-                    # vCard represents information about an individual or entity.
-                    vcard_type = vcard[0]
-                    vcard_value = vcard[-1]
-                    # check for organization
-                    if vcard_type == RDAPVCardKeys.ORG:
-                        ent_dict["org"] = vcard_value
-                    # check for email
-                    elif vcard_type == RDAPVCardKeys.EMAIL:
-                        ent_dict["email"] = vcard_value
-                    # check for email
-                    elif vcard_type == RDAPVCardKeys.CONTACT:
-                        ent_dict["contact-uri"] = vcard_value
-                    # check for name
-                    elif vcard_type == RDAPVCardKeys.FN:
-                        ent_dict["name"] = vcard_value
-                    # check for address
-                    elif vcard_type == RDAPVCardKeys.ADR:
-                        values = self._flatten_list(vcard_value)
-                        address_string = ", ".join([v for v in values if v])
-                        ent_dict["address"] = address_string.lstrip()
-                    # check for contact
-                    elif vcard_type == RDAPVCardKeys.TEL:
-                        # check the "type" of "tel" vcard (either voice or fax):
-                        # vcard looks like: ['tel', {"type": "voice"}, 'uri', 'tel:0000000']
-                        #               or: ['tel', {"type": ["voice"]}, 'uri', 'tel:0000000']
-                        if hasattr(vcard[1], "type"):
-                            contact_type = vcard[1].to_dict().get("type")
-                            if contact_type == "voice" or "voice" in contact_type:
-                                ent_dict["phone"] = vcard_value
-                            elif contact_type == "fax" or "fax" in contact_type:
-                                ent_dict["fax"] = vcard_value
+                # basic validation for vcard
+                conformance_check_exc = self._check_valid_vcardArray(entity.vcardArray)
+                if conformance_check_exc is not None:
+                    if strict:
+                        raise conformance_check_exc
+                    else:
+                        # skip because vcardArray parsing is likely to fail
+                        continue
+                else:
+                    # parse vcards
+                    for vcard in entity.vcardArray[-1]:
+                        conformance_check_exc = self._check_valid_vcard(vcard)
+                        if conformance_check_exc is not None:
+                            if strict:
+                                raise conformance_check_exc
+                            else:
+                                # skip because vcard parsing is likely to fail
+                                continue
                         else:
-                            ent_dict["phone"] = vcard_value
+                            # vCard represents information about an individual or entity.
+                            vcard_type = vcard[0]
+                            vcard_value = vcard[-1]
+                            # check for organization
+                            if vcard_type == RDAPVCardKeys.ORG:
+                                ent_dict["org"] = vcard_value
+                            # check for email
+                            elif vcard_type == RDAPVCardKeys.EMAIL:
+                                ent_dict["email"] = vcard_value
+                            # check for email
+                            elif vcard_type == RDAPVCardKeys.CONTACT:
+                                ent_dict["contact-uri"] = vcard_value
+                            # check for name
+                            elif vcard_type == RDAPVCardKeys.FN:
+                                ent_dict["name"] = vcard_value
+                            # check for address
+                            elif vcard_type == RDAPVCardKeys.ADR:
+                                values = self._flatten_list(vcard_value)
+                                address_string = ", ".join([v for v in values if v])
+                                ent_dict["address"] = address_string.lstrip()
+                            # check for contact
+                            elif vcard_type == RDAPVCardKeys.TEL:
+                                # check the "type" of "tel" vcard (either voice or fax):
+                                # vcard looks like: ['tel', {"type": "voice"}, 'uri', 'tel:0000000']
+                                #               or: ['tel', {"type": ["voice"]}, 'uri', 'tel:0000000']
+                                if hasattr(vcard[1], "type"):
+                                    contact_type = vcard[1].to_dict().get("type")
+                                    if contact_type == "voice" or "voice" in contact_type:
+                                        ent_dict["phone"] = vcard_value
+                                    elif contact_type == "fax" or "fax" in contact_type:
+                                        ent_dict["fax"] = vcard_value
+                                else:
+                                    ent_dict["phone"] = vcard_value
 
             # add roles for this entity
-            for role in entity.roles:
-                if mark_redacted:
-                    for key in ("address", "phone", "name", "org", "email", "fax"):
-                        if not ent_dict.get(key):
-                            ent_dict[key] = REDACTED
-                # save the information under this "role"
-                entities_dict[role.lower()] = ent_dict
+            if hasattr(entity, "roles"):
+                for role in entity.roles:
+                    if mark_redacted:
+                        for key in ("address", "phone", "name", "org", "email", "fax"):
+                            if not ent_dict.get(key):
+                                ent_dict[key] = REDACTED
+                    # save the information under this "role"
+                    entities_dict[role.lower()] = ent_dict
 
         # return parsed entities dict
         return entities_dict


### PR DESCRIPTION
This is a temporary fix for preventing issues `to_whois_dict` raising `TypeError`'s for non-conformant RDAP responses (#29).
The `strict` parameter was added to `to_whois_dict`. If True, the method will raise an `RDAPConformanceException` when it encounters bad responses. If False, the method will "skip" the incorrectly formatted entity.

In the near future, the validation method should be expanded into it's own set of methods or method and more closely align with jsonschema validation.