### PR TITLE
Prevent crashing on `_convert_date`

### DIFF
--- a/whodap/response.py
+++ b/whodap/response.py
@@ -150,7 +150,7 @@ class DomainResponse(RDAPResponse):
         otherwise returns the value of the given attribute
         """
         val = super().__getattribute__(item)
-        if item == "eventDate":
+        if item == "eventDate" and val:
             return self._convert_date(val)
         return val
 


### PR DESCRIPTION
Only call `_convert_date` if the value is not null. I'm getting runtime errors for this.