### PR TITLE
add py.typed

### DIFF
--- a/whodap/client.py
+++ b/whodap/client.py
@@ -1,4 +1,3 @@
-import sys
 import posixpath
 import ipaddress
 from typing import Any, Union, cast, TypeAlias


### PR DESCRIPTION
to support type checking by users of the package i added py.typed  
see; https://typing.python.org/en/latest/spec/distributing.html#packaging-typed-libraries

as a side note:the client.py had a unused include sys, ruff cleaned it up